### PR TITLE
Fix 404 Error in docs

### DIFF
--- a/docs/proxies/ultraviolet.mdx
+++ b/docs/proxies/ultraviolet.mdx
@@ -10,7 +10,7 @@ Highly sophisticated proxy used for evading internet censorship or accessing web
 
 ## Setup
 
-Ultraviolet works by intercepting HTTP requests with a service worker script that follows the TompHTTP specifications. More information regarding TompHTTP can be found [here](../tomphttp).
+Ultraviolet works by intercepting HTTP requests with a service worker script that follows the TompHTTP specifications. More information regarding TompHTTP can be found [here](../../tomphttp).
 
 The components of Ultraviolet are as follows:
 


### PR DESCRIPTION
In the "ultraviolet.mdx" file there is a "learn more about TompHTTP here" link. The link leads to a 404 error. The link is "../tomphttp", which goes to https://docs.titaniumnetwork.org/proxies/tomphttp which does not exist. The link is supposed to be "../../tomphttp", which leads to https://docs.titaniumnetwork.org/tomphttp which does exist. I fixed the issue and now the link leads to the correct file location.