### PR TITLE
feat: doc updates

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,20 +1,20 @@
 export default {
   plugins: [
-    'remark-frontmatter',
-    'remark-gfm',
-    'remark-mdx',
+    "remark-frontmatter",
+    "remark-gfm",
+    "remark-mdx",
     [
-      'remark-stringify',
+      "remark-stringify",
       {
-        bullet: '-',
-        listItemIndent: 'one',
-        emphasis: '*',
-        strong: '*',
+        bullet: "-",
+        listItemIndent: "one",
+        emphasis: "*",
+        strong: "*",
         fences: true,
-        fence: '`',
-        rule: '-',
-        incrementListMarker: true
-      }
-    ]
-  ]
+        fence: "`",
+        rule: "-",
+        incrementListMarker: true,
+      },
+    ],
+  ],
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
     "editor.formatOnSave": true
   },
   "[mdx]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "editor.defaultFormatter": "unifiedjs.vscode-mdx",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,52 +1,74 @@
-import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+import rehypeAstroRelativeMarkdownLinks from "astro-rehype-relative-markdown-links";
+import rehypeShiki from "@shikijs/rehype";
 
 // https://astro.build/config
 export default defineConfig({
-	site: "https://docs.titaniumnetwork.org",
-
-	integrations: [
-		starlight({
-			title: "Titanium Network",
-			favicon: "/favicon.png",
-			social: {
-				github: "https://github.com/titaniumnetwork-dev/Oxide-Docs",
-				discord: "https://discord.gg/unblock",
-			},
-			components: {
-				Head: "./src/components/MetadataHead.astro",
-			},
-			sidebar: [
-				{
-					label: "Guides",
-					autogenerate: { directory: "guides" },
-				},
-				{
-					label: "Services",
-					autogenerate: { directory: "services" },
-				},
-				{
-					label: "Proxies",
-					autogenerate: { directory: "proxies" },
-				},
-				{
-					label: "Technologies",
-					autogenerate: { directory: "technologies" },
-				},
-				{
-					label: "Transports",
-					autogenerate: { directory: "transports" },
-				},
-				{
-					label: "Kajigs",
-					autogenerate: { directory: "kajigs" },
-				},
-			],
-			customCss: [
-				"./src/styles/custom.css",
-				"@fontsource/raleway/400.css",
-				"@fontsource/raleway/600.css",
-			],
-		}),
-	],
+  site: "https://docs.titaniumnetwork.org",
+  markdown: {
+    rehypePlugins: [
+      [
+        rehypeAstroRelativeMarkdownLinks,
+        {
+          collectionBase: false,
+        },
+      ],
+      [
+        rehypeShiki,
+        {
+          inline: "tailing-curly-colon",
+          themes: {
+            light: "tokyo-night",
+            dark: "tokyo-night",
+          },
+        },
+      ],
+    ],
+  },
+  integrations: [
+    starlight({
+      title: "Titanium Network",
+      favicon: "/favicon.png",
+      social: {
+        github: "https://github.com/titaniumnetwork-dev/Oxide-Docs",
+        discord: "https://discord.gg/unblock",
+      },
+      components: {
+        Head: "./src/components/MetadataHead.astro",
+        PageTitle: "./src/components/PageTitle.astro",
+      },
+      sidebar: [
+        {
+          label: "Guides",
+          autogenerate: { directory: "guides" },
+        },
+        {
+          label: "Services",
+          autogenerate: { directory: "services" },
+        },
+        {
+          label: "Proxies",
+          autogenerate: { directory: "proxies" },
+        },
+        {
+          label: "Technologies",
+          autogenerate: { directory: "technologies" },
+        },
+        {
+          label: "Transports",
+          autogenerate: { directory: "transports" },
+        },
+        {
+          label: "Kajigs",
+          autogenerate: { directory: "kajigs" },
+        },
+      ],
+      customCss: [
+        "./src/styles/custom.css",
+        "@fontsource/raleway/400.css",
+        "@fontsource/raleway/600.css",
+      ],
+    }),
+  ],
 });

--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,11 @@
 {
   "files": {
     "includes": [
-      "!node_modules/**",
-      "!dist/**",
-      "!.astro/**",
-      "!.vscode/**",
+      "**",
+      "!node_modules",
+      "!dist",
+      "!.astro",
+      "!.vscode",
       "!**/*.mdx",
       "!**/*.md",
       "!LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,41 +1,48 @@
 {
-	"name": "docs",
-	"description": "The official SDK documentation site for TitaniumNetwork.",
-	"homepage": "https://docs.titaniumnetwork.org/",
-	"license": "AGPLv3",
-	"repository": "https://github.com/titaniumnetwork-dev/Oxide-Docs",
-	"type": "module",
-	"version": "3.0.0",
-	"scripts": {
-		"dev": "astro dev",
-		"start": "astro dev",
-		"build": "astro check && astro build",
-		"preview": "astro preview",
-		"astro": "astro",
-		"fmt": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome format --write .",
-		"fmt-check": "remark \"src/content/docs/**/*.{md,mdx}\" && biome format .",
-		"lint": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome lint --write .",
-		"lint-check": "remark \"src/content/docs/**/*.{md,mdx}\" && biome lint .",
-		"check": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome check --write .",
-		"check-ci": "remark \"src/content/docs/**/*.{md,mdx}\" && biome check ."
-	},
-	"dependencies": {
-		"@astrojs/check": "^0.9.4",
-		"@astrojs/starlight": "^0.29.3",
-		"@fontsource/raleway": "^5.2.6",
-		"astro": "^4.16.18",
-		"sharp": "^0.32.6",
-		"typescript": "^5.9.2"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.1.4",
-		"@mdx-js/mdx": "^3.0.1",
-		"remark": "^15.0.1",
-		"remark-cli": "^12.0.1",
-		"remark-frontmatter": "^5.0.0",
-		"remark-gfm": "^4.0.0",
-		"remark-mdx": "^3.0.1",
-		"remark-stringify": "^11.0.0",
-		"unified": "^11.0.5"
-	}
+  "name": "docs",
+  "description": "The official SDK documentation site for TitaniumNetwork.",
+  "homepage": "https://docs.titaniumnetwork.org/",
+  "license": "AGPLv3",
+  "repository": "https://github.com/titaniumnetwork-dev/Oxide-Docs",
+  "type": "module",
+  "version": "3.0.0",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro check && astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "typecheck": "astro check",
+    "typecheck-full": "astro check && tsc --noEmit --skipLibCheck",
+    "fmt": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome format --write .",
+    "fmt-check": "remark \"src/content/docs/**/*.{md,mdx}\" && biome format .",
+    "lint": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome lint --write .",
+    "lint-check": "remark \"src/content/docs/**/*.{md,mdx}\" && biome lint .",
+    "check": "remark \"src/content/docs/**/*.{md,mdx}\" --output && biome check --write .",
+    "check-ci": "remark \"src/content/docs/**/*.{md,mdx}\" && biome check ."
+  },
+  "dependencies": {
+    "@astrojs/check": "^0.9.4",
+    "@astrojs/starlight": "^0.29.3",
+    "@fontsource/raleway": "^5.2.6",
+    "@shikijs/rehype": "^3.12.0",
+    "@shikijs/themes": "^3.12.0",
+    "astro": "^4.16.19",
+    "astro-rehype-relative-markdown-links": "^0.18.1",
+    "gray-matter": "^4.0.3",
+    "sharp": "^0.32.6",
+    "typescript": "^5.9.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.2.2",
+    "@mdx-js/mdx": "^3.1.1",
+    "remark": "^15.0.1",
+    "remark-cli": "^12.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-mdx": "^3.1.1",
+    "remark-stringify": "^11.0.0",
+    "remark-yaml-config": "^7.0.0",
+    "unified": "^11.0.5"
+  }
 }

--- a/src/components/MetadataHead.astro
+++ b/src/components/MetadataHead.astro
@@ -2,14 +2,13 @@
 import type { Props } from "@astrojs/starlight/props";
 
 /**
- * Custom overrides for the frontmatter data used for the OpenGraph metadata. Extends the existing frontmatter setup.
+ * The expected frontmatter to configure metadata tag generation
  */
 interface MetadataFrontmatter {
   title: string;
   description?: string;
   image?: string;
   keywords?: string[];
-  version?: string;
   themeColor?: string;
 }
 
@@ -18,26 +17,34 @@ const { data: frontmatter } = entry;
 const { title, description } = frontmatter;
 
 /**
- * The default frontmatter data, which will be the data used for the OpenGraph metadata defaults.
+ * The default frontmatter data
  */
-const defaults = {
+const DEFAULT_METADATA = {
   siteName: "Titanium Network Docs",
   twitterHandle: "@TitaniumNetDev",
   defaultImage:
     "https://raw.githubusercontent.com/titaniumnetwork-dev/Oxide/master/public/logo.png",
   defaultDescription:
     "Open Source Proxy Organization; Here we provide advanced web proxy services through the progression of web proxy technologies.",
-  version: "1.0.10",
   themeColor: "#434c5e",
 } as const;
 
-const metadataFrontmatter = frontmatter as MetadataFrontmatter;
-const image = metadataFrontmatter.image || defaults.defaultImage;
-const keywords = metadataFrontmatter.keywords || [];
-const version = metadataFrontmatter.version || defaults.version;
-const themeColor = metadataFrontmatter.themeColor || defaults.themeColor;
-const path = Astro.url.pathname;
-const canonicalUrl = Astro.site ? new URL(path, Astro.site).href : undefined;
+/**
+ * The frontmatter for an MDX doc
+ */
+const FRONTMATTER = frontmatter as MetadataFrontmatter;
+/**
+ * The image to generate for the metadata
+ */
+const IMAGE = FRONTMATTER.image || DEFAULT_METADATA.defaultImage;
+/**
+ * The keywords to generate for the metadata
+ */
+const KEYWORDS = FRONTMATTER.keywords || [];
+/**
+ * The theme color to generate for the metadata
+ */
+const THEME_COLOR = FRONTMATTER.themeColor || DEFAULT_METADATA.themeColor;
 ---
 
 <!-- Unofficial Web Standards -->
@@ -48,7 +55,6 @@ const canonicalUrl = Astro.site ? new URL(path, Astro.site).href : undefined;
   content="width=device-width, initial-scale=1.0, shrink-to-fit=no"
 />
 <link rel="manifest" href="https://titaniumnetwork.org/manifest.json" />
-{canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
 <link rel="icon" type="image/png" href="https://titaniumnetwork.org/logo.png" />
 <link
   rel="apple-touch-icon"
@@ -73,32 +79,30 @@ const canonicalUrl = Astro.site ? new URL(path, Astro.site).href : undefined;
   color="#b4213b"
 />
 <meta name="msapplication-TileColor" content="#b4213b" />
-<meta name="version" content={version} />
 <meta
   name="theme-color"
   media="(prefers-color-scheme: dark)"
-  content={themeColor}
+  content={THEME_COLOR}
 />
 <title>{title || "Untitled Page"}</title>
 {description && <meta name="description" content={description} />}
-{keywords.length > 0 && <meta name="keywords" content={keywords.join(", ")} />}
+{KEYWORDS.length > 0 && <meta name="keywords" content={KEYWORDS.join(", ")} />}
 
 <!-- OpenGraph metadata -->
 <meta property="og:title" content={title || "Untitled Page"} />
 {description && <meta property="og:description" content={description} />}
-<meta property="og:image" content={image} />
-<meta property="og:site_name" content={defaults.siteName} />
+<meta property="og:image" content={IMAGE} />
+<meta property="og:site_name" content={DEFAULT_METADATA.siteName} />
 <meta property="og:type" content="website" />
-{canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-<meta property="og:image:secure_url" content={image} />
+<meta property="og:image:secure_url" content={IMAGE} />
 
 <!-- Twitter Card metadata -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content={defaults.twitterHandle} />
-<meta name="twitter:creator" content={defaults.twitterHandle} />
-<meta name="twitter:title" content={title || defaults.siteName} />
+<meta name="twitter:site" content={DEFAULT_METADATA.twitterHandle} />
+<meta name="twitter:creator" content={DEFAULT_METADATA.twitterHandle} />
+<meta name="twitter:title" content={title || DEFAULT_METADATA.siteName} />
 <meta
   name="twitter:description"
-  content={description || defaults.defaultDescription}
+  content={description || DEFAULT_METADATA.defaultDescription}
 />
-<meta name="twitter:image" content={image} />
+<meta name="twitter:image" content={IMAGE} />

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import AutoAttributionButtons from "./attribution/AutoAttributionButtons.astro";
+
+/** Extracted slug from the current URL. */
+const SLUG = Astro.url.pathname.replace(/^\/+|\/+$/g, "");
+/** All documents from the 'docs' content collection. */
+const DOCS = await getCollection("docs");
+/** Document matching the current slug if found. */
+const MATCHING_DOC: CollectionEntry<"docs"> | undefined = DOCS.find(
+  (doc: CollectionEntry<"docs">) => doc.slug === SLUG
+);
+/** Frontmatter data from the matching document, or empty object as fallback. */
+const FRONTMATTER_DATA = MATCHING_DOC?.data ?? {
+  title: "No Title",
+  description: "",
+  github: undefined,
+  discord: undefined,
+  "official-link": undefined,
+};
+/** Page title from frontmatter with fallback. */
+const TITLE = FRONTMATTER_DATA.title || "No Title";
+/** Whether the document has a GitHub link configured. */
+const HAS_GITHUB = Boolean(FRONTMATTER_DATA.github);
+/** Whether the document has a Discord link configured. */
+const HAS_DISCORD = Boolean(FRONTMATTER_DATA.discord);
+/** Whether the document has an official link configured. */
+const HAS_OFFICIAL_LINK = Boolean(FRONTMATTER_DATA["official-link"]);
+/** Whether to show attribution buttons based on available links. */
+const SHOULD_SHOW_BUTTONS = HAS_GITHUB || HAS_DISCORD || HAS_OFFICIAL_LINK;
+---
+
+<h1 id="_top">{TITLE}</h1>
+{
+  SHOULD_SHOW_BUTTONS && (
+    <div class="attribution-wrapper">
+      <AutoAttributionButtons frontmatter={FRONTMATTER_DATA} />
+    </div>
+  )
+}

--- a/src/components/attribution/AutoAttributionButtons.astro
+++ b/src/components/attribution/AutoAttributionButtons.astro
@@ -1,0 +1,49 @@
+---
+const frontmatter = Astro.props.frontmatter || Astro.props;
+const { github, discord, "official-link": officialLink } = frontmatter;
+
+import SocialIconsClone from "./SocialIconsClone.astro";
+
+const links = [];
+
+if (github) {
+  links.push({
+    href: github,
+    label: "View on GitHub",
+    icon: "github" as const,
+  });
+}
+
+if (discord) {
+  links.push({
+    href: discord,
+    label: "Join Discord Server",
+    icon: "discord" as const,
+  });
+}
+
+if (officialLink) {
+  links.push({
+    href: officialLink,
+    label: "Visit Official Site",
+    icon: "external" as const,
+  });
+}
+---
+
+{
+  links.length > 0 && (
+    <div class="attribution-buttons">
+      <SocialIconsClone links={links} />
+    </div>
+  )
+}
+
+<style>
+  .attribution-buttons {
+    display: inline-flex;
+    margin-left: 0.75rem;
+    gap: 1rem;
+    align-items: center;
+  }
+</style>

--- a/src/components/attribution/SocialIconsClone.astro
+++ b/src/components/attribution/SocialIconsClone.astro
@@ -1,0 +1,37 @@
+---
+import { Icon } from "@astrojs/starlight/components";
+
+export interface Props {
+  links: Array<{
+    href: string;
+    label: string;
+    icon: "github" | "discord" | "external";
+  }>;
+}
+
+const { links } = Astro.props;
+---
+
+{
+  links.length > 0 && (
+    <>
+      {links.map(({ label, href, icon }) => (
+        <a {href} rel="me noopener noreferrer" class="sl-flex" target="_blank">
+          <span class="sr-only">{label}</span>
+          <Icon name={icon} />
+        </a>
+      ))}
+    </>
+  )
+}
+
+<style>
+  a {
+    color: var(--sl-color-text-accent);
+    padding: 0.5em;
+    margin: -0.5em;
+  }
+  a:hover {
+    opacity: 0.66;
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,6 +1,14 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
+  docs: defineCollection({
+    schema: docsSchema({
+      extend: z.object({
+        github: z.string().optional(),
+        discord: z.string().optional(),
+        "official-link": z.string().optional(),
+      }),
+    }),
+  }),
 };

--- a/src/content/docs/guides/seo-guide.mdx
+++ b/src/content/docs/guides/seo-guide.mdx
@@ -653,15 +653,15 @@ The main takeaways here are to remember the use:
             <div class="footerlist">
                 <h3>Services</h3>
                 <ul>
-                    <li><a target="_blank" href="https://github.com/titaniumnetwork-dev">Ultraviolet</a></li>
-                    <li><a target="_blank" href="https://discord.gg/VNT4E7gN5Y">Rammerhead</a></li>
+                    <li><a target="_blank" href="/proxies/ultraviolet">Ultraviolet</a></li>
+                    <li><a target="_blank" href="/proxies/rammerhead">Rammerhead</a></li>
                     <li><a target="_blank" href="https://github.com/binary-person/womginx">Womginx</a></li>
                 </ul>
             </div>
             <div class="footerlist">
                 <h3>About</h3>
                 <ul>
-                    <li><a target="_blank" href="https://github.com/QuiteAFancyEmerald/Holy-Unblocker">GitHub</a></li>
+                    <li><a target="_blank" href="/services/holy-unblocker">GitHub</a></li>
                     <li><a href="/?t">Privacy and Terms of Service</a></li>
                     <li><a href="/?c">Credits</a></li>
                 </ul>
@@ -684,7 +684,7 @@ The main takeaways here are to remember the use:
 
 - [Emerald's website](https://hutao.dev/)
 - [Holy Unblocker Official Link](https://holyunblocker.org//)
-- [Holy Unblocker GitHub Repository](https://github.com/QuiteAFancyEmerald/Holy-Unblocker/)
+- [Holy Unblocker GitHub Repository](/services/holy-unblocker)
 - [TN GitHub Organization](https://github.com/titaniumnetwork-dev/)
 - [TN official website](https://titaniumnetwork.org/)
 

--- a/src/content/docs/guides/ssl-guide.mdx
+++ b/src/content/docs/guides/ssl-guide.mdx
@@ -7,7 +7,7 @@ description: For this tutorial Certbot will be used. Other open source clients w
 
 For this tutorial, [Certbot](https://certbot.eff.org/) will be used. You can use other open-source clients that utilize **Let's Encrypt** if you wish.
 
-> Certbot is a free, open-source software tool for automatically using Let’s Encrypt certificates on manually administered websites to enable HTTPS.
+> Certbot is a free, open-source software tool for automatically using Let's Encrypt certificates on manually administered websites to enable HTTPS.
 
 Certbot is an interface with the Let's Encrypt service, a CLI tool for generating and renewing certificates. In this example, Canonical Ubuntu 20.04 will be used.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -12,6 +12,7 @@ hero:
       link: https://github.com/titaniumnetwork-dev/Oxide-Docs
       icon: external
       variant: minimal
+github: "https://github.com/titaniumnetwork-dev/Oxide-Docs"
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/kajigs/downgrading.mdx
+++ b/src/content/docs/kajigs/downgrading.mdx
@@ -13,7 +13,7 @@ Please refer to [Kernel Version Info](/kajigs/kernverinfo) to see what versions 
 ## What do I need?
 
 - USB drive (8 GB+)
-- One of the following: [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm) (ChromeOS, Windows, MacOS), `dd` (Linux/macOS/POSIX-compliant), or balenaEtcher (Linux, MacOS, Windows)
+- One of the following: [Chromebook Recovery Utility](https://chrome.google.com/webstore/detail/chromebook-recovery-utili/pocpnlppkickgojjlmhdmidojbmbodfm) (ChromeOS, Windows, MacOS), `dd{:sh}` (Linux/macOS/POSIX-compliant), or balenaEtcher (Linux, MacOS, Windows)
 
 ## Step 1: Find your board name
 
@@ -59,8 +59,8 @@ Then proceed to the next step but instead of board name assume device name (i.e.
 
 ### Option 3: Using dd (Linux/macOS/POSIX-compliant):
 
-1. Unzip the `.zip` file either through GUI, or through a command like `unzip`
-2. Identify your USB device by running `sudo fdisk -l` (Linux) or using macOS Disk Utility. It should say something like `Disk /dev/sd...` (Linux) and in macOS open Disk Utility, select it under "External" and you should see `Device:`. You will want to use `/dev/INSERTTHATNAMEHERE` instead of `/dev/sdX`. Other OSes will have to see relevant documentation for identifying the proper USB device.
+1. Unzip the `.zip` file either through GUI, or through a command like `unzip{:sh}`
+2. Identify your USB device by running `sudo fdisk -l{:sh}` (Linux) or using macOS Disk Utility. It should say something like `Disk /dev/sd...` (Linux) and in macOS open Disk Utility, select it under "External" and you should see `Device:`. You will want to use `/dev/INSERTTHATNAMEHERE` instead of `/dev/sdX`. Other OSes will have to see relevant documentation for identifying the proper USB device.
 3. Write the image (replace `/dev/sdX` and file path. Remember to use the unzipped file):
 
 ```bash
@@ -76,4 +76,4 @@ Double-check the device name to avoid data loss!
 1. Enter recovery mode: <kbd>Esc</kbd> + <kbd>Refresh</kbd> + <kbd>Power</kbd>
 2. Insert recovery USB
 3. Follow prompts to reinstall Chrome OS
-4. Remove USB when done. You can wipe it in Chrome OS Recovery Utility with gear icon → "erase recovery media". You can `mkfs.ext4` on the block device in Linux (on Mac use Disk Utility or CRU).
+4. Remove USB when done. You can wipe it in Chrome OS Recovery Utility with gear icon → "erase recovery media". You can `mkfs.ext4{:sh}` on the block device in Linux (on Mac use Disk Utility or CRU).

--- a/src/content/docs/kajigs/dump-kiosk.mdx
+++ b/src/content/docs/kajigs/dump-kiosk.mdx
@@ -11,7 +11,7 @@ You need to have linux experience for this.
 1. Enable devmode using [SH1MMER](https://sh1mmer.me/)
 2. Add your personal Google account
 3. Add your school account
-4. Open a crosh shell <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>, run `shell`, go to `/home/chronos/(hash of your user account)/extensions/kiosk/` and find the ID that goes with your kiosk apps
+4. Open a crosh shell <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>, run `shell{:sh}`, go to `/home/chronos/(hash of your user account)/extensions/kiosk/` and find the ID that goes with your kiosk apps
 
 | Kiosk             | ID                                 |
 | ----------------- | ---------------------------------- |
@@ -20,9 +20,9 @@ You need to have linux experience for this.
 | NWEA              | `omkghcboodpimaoimdkmigofhjcpmpeb` |
 | CollegeBoard      | `joaneffahikmmipmidpkeedopejmhbbm` |
 
-5. Back it up to your downloads folder with `cp /home/chronos/(hash of your user account)/extensions/kiosk/(app ID) /home/chronos/<hash of your account id>/Downloads/`.
+5. Back it up to your downloads folder with `cp /home/chronos/(hash of your user account)/extensions/kiosk/(app ID) /home/chronos/<hash of your account id>/Downloads/{:sh}`.
 6. Zip it with the file manager
-7. Go into the folder and edit the `manifest.json` and delete the line `"kiosk_only" : true"`
+7. Go into the folder and edit the `manifest.json` and delete the line `"kiosk_only" : true"{:json}`
 8. Backup the folder anywhere you would like, USB, Google Drive, it doesn't matter
 9. Unenroll again and go to any user
 10. Copy the backup over to your Chromebook and unzip it into a folder

--- a/src/content/docs/kajigs/incognito.mdx
+++ b/src/content/docs/kajigs/incognito.mdx
@@ -17,10 +17,10 @@ This relies on you being between version 123 and version 127. See [ChromeOS Vers
 ## **Instructions:**
 
 1. Go to `chrome://flags/#captive-portal-popup-window`. If you're on v126-v127 use the temporary unexpire flags: chrome://flags/#temporary-unexpire-flags-m124 (v126) and chrome://flags/#temporary-unexpire-flags-m125 (v126 and v127).
-2. If it doesn’t exist, make sure to be on chromeOS v123-v127. If you're on v128+, you need to downgrade to v123-v127.
+2. If it doesn't exist, make sure to be on chromeOS v123-v127. If you're on v128+, you need to downgrade to v123-v127.
 3. Enable it.
 4. Restart.
-5. If the flag didn’t reset, you can continue. Else you cannot.
+5. If the flag didn't reset, you can continue. Else you cannot.
 6. Go to Settings.
 7. Click Wi-Fi in the Network section.
 8. Click your Wi-Fi.

--- a/src/content/docs/kajigs/legacy-kajigs.mdx
+++ b/src/content/docs/kajigs/legacy-kajigs.mdx
@@ -125,16 +125,16 @@ You need a usb for downgrading, and rudimentary knowledge of bash is recommended
 
 Downgrade to any version below 103. Instructions are in "Chrome OS Downloads - Downgrade your Chrome OS".
 
-Hit <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd> to open a crosh window. If it’s blocked by extensions, use LTBEEF. If it’s policy blocked (“The person who set up this computer has chosen to block this site”) you can try downgrading to a version below 90, where crosh had a different URL
-Type in `set_cellular_ppp \';bash;exit;\'` and hit enter.
+Hit <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd> to open a crosh window. If it's blocked by extensions, use LTBEEF. If it's policy blocked (“The person who set up this computer has chosen to block this site”) you can try downgrading to a version below 90, where crosh had a different URL
+Type in `set_cellular_ppp \';bash;exit;\'{:sh}` and hit enter.
 
 You now have access to a bash shell, logged in as chronos. More information about the permissions of this shell is at the bottom.
 
-Type `rm -rf ~/Extensions/*`. THIS WILL BREAK EVERY EXTENSION ON YOUR CHROMEBOOK. If there are extensions you want to keep, they can be selectively removed by ID.
+Type `rm -rf ~/Extensions/*{:sh}`. THIS WILL BREAK EVERY EXTENSION ON YOUR CHROMEBOOK. If there are extensions you want to keep, they can be selectively removed by ID.
 
-Run `chmod 000 ~/Extensions`. This marks the extension folder as read only, stopping it from updating in the future or any new extensions from being installed.
+Run `chmod 000 ~/Extensions{:sh}`. This marks the extension folder as read only, stopping it from updating in the future or any new extensions from being installed.
 
-You can now restart chrome, allowing it to update to the latest version. Once rebooted onto the latest version, all removed extensions will have the default icon and won’t function at all
+You can now restart chrome, allowing it to update to the latest version. Once rebooted onto the latest version, all removed extensions will have the default icon and won't function at all
 
 **If you would like Root Access, go to Root Escalation**
 
@@ -146,7 +146,7 @@ You can also run `set_cellular_ppp \'chmod 777 ~/Extensions;rm -rf ~/Extensions;
 
 Have the ability to run developer mode content, enable developer mode, bypass pretty much everything with one exploit. Will require the downgrade methods.
 
-Has so many branches that I’m just going to link the Kajig discussion. Check the pins in the TN Discord server.
+Has so many branches that I'm just going to link the Kajig discussion. Check the pins in the TN Discord server.
 
 [TN Discord Message Reference](https://discord.com/channels/419123358698045453/1033537020854800434)
 
@@ -202,7 +202,7 @@ When you connect to a Wi-Fi without the custom DNS the policy will reload to nor
 - Downgrade to a version
 - Open crosh (<kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>)
 - Elevate to a chronos shell by typing in set\_cellular\_ppp ';bash;exit'
-- Run the command `sh <(curl -k https://coolelectronics.me/bypass.sh) & disown`
+- Run the command `sh <(curl -k https://coolelectronics.me/bypass.sh) & disown{:sh}`
 - Remove your school account, log out or just clear it in any way you can. The method varies depending on how device policy is set up.
 - In your router settings, set the DNS to `129.213.58.41` or `block m.google.com`. (NOT THE NETWORK DNS ON THE CHROMEBOOK, IT WONT WORK; ROUTER!)
 
@@ -299,9 +299,9 @@ This builds off of Permanently Remove Extensions (past v106).
 
 Follow the instructions there, and stop once you have the bash shell.
 
-- Run `cd ~/Downloads`
-- Run `vi exploit.sh` to create a new shell file.
-- In this shell file, put the line `pkill -9 chrome`
+- Run `cd ~/Downloads{:sh}`
+- Run `vi exploit.sh{:sh}` to create a new shell file.
+- In this shell file, put the line `pkill -9 chrome{:sh}`
 - After that, head over to `chrome:version`, and next to "command line options:" copy the entire really long thing
 - Paste it into vi as a new line.
 
@@ -311,7 +311,7 @@ The full list is here: [https://peter.sh/experiments/chromium-command-line-switc
 
 Some notable ones are: `--force-devtools-available` (devtools), `--bwsi` (guest mode), `--kiosk`(useless but funny), `--oauth-client-id`(breaks policy updating and profile syncing), `--disable-extensions-except`, `--show-login-dev-overlay`/`--show-oobe-dev-overlay`, `--enable-hangout-services-extension-for-testing`(adds a bunch of useless extensions), and more.
 
-To execute chrome with the launch options set, exit vi (impossible), and run `sh <(cat exploit.sh) & disown`
+To execute chrome with the launch options set, exit vi (impossible), and run `sh <(cat exploit.sh) & disown{:sh}`
 
 ## IStealYourDNS (DNS)
 
@@ -401,7 +401,7 @@ The following exploit is still a massive WIP and the following above may be subj
 - Scroll all the way to the bottom and find your blocker extension and highlight it (click on it)
 - Click 'End Process' it or press <kbd>Enter</kbd>
 - Immediately go to your page and see that it's unblocked
-- This will not last unless you use this bookmarklet `javascript:onbeforeunload=i=>1`
+- This will not last unless you use this bookmarklet `javascript:onbeforeunload=i=>1{:js}`
 
 If Task Manager is blocked:
 

--- a/src/content/docs/kajigs/lockdown-browser.mdx
+++ b/src/content/docs/kajigs/lockdown-browser.mdx
@@ -19,4 +19,4 @@ This requires the eduphoria lockdown browser.
 No tabs
 No windows
 No extensions
-You can’t type URLs manually
+You can't type URLs manually

--- a/src/content/docs/kajigs/rootless-unenrollment.mdx
+++ b/src/content/docs/kajigs/rootless-unenrollment.mdx
@@ -15,7 +15,7 @@ This relies on you being at or below version 101. See [ChromeOS Versioning](/kaj
 
 # Guide
 
-Run this as `chronos`:
+Run this as `chronos{:sh}`:
 
 ```
 dbus-send --system --print-reply --dest=org.chromium.SessionManager /org/chromium/SessionManager org.chromium.SessionManagerInterface.ClearForcedReEnrollmentVpd

--- a/src/content/docs/kajigs/shimboot.mdx
+++ b/src/content/docs/kajigs/shimboot.mdx
@@ -16,7 +16,7 @@ Shimboot is a collection of scripts for patching a Chrome OS RMA shim to serve a
 
 Chrome OS RMA shims are bootable disk images which are designed to run a variety of diagnostic utilities on Chromebooks, and they'll work even if the device is enterprise enrolled. Unfortunately for Google, there exists a security flaw in which the root filesystem of the RMA shim is not verified. This lets us replace the rootfs with anything we want, including a full Linux distribution.
 
-Simply replacing the shim's `rootfs` doesn't work, however, as it boots to an environment friendly to the RMA shim, not regular Linux distros. To get around this, a separate bootloader is required to transition from the shim environment to the main `rootfs`. This bootloader then does a `pivot_root` to enter the `rootfs`, where it runs the init system.
+Simply replacing the shim's `rootfs` doesn't work, however, as it boots to an environment friendly to the RMA shim, not regular Linux distros. To get around this, a separate bootloader is required to transition from the shim environment to the main `rootfs`. This bootloader then does a `pivot_root{:sh}` to enter the `rootfs`, where it runs the init system.
 
 Another problem is encountered at this stage: the Chrome OS kernel will complain about `systemd`'s mounts, and the boot process will hang. A simple workaround is to apply a patch to `systemd`, and then it can be recompiled and hosted at a repo somewhere.
 

--- a/src/content/docs/kajigs/terra.mdx
+++ b/src/content/docs/kajigs/terra.mdx
@@ -20,12 +20,12 @@ You'll need to create a partition with the type `chromeOS rootfs` (`3cb8e202-3b7
 
 Make sure you use an Arch Linux system as other distros are not supported due to the lack of scripts for bootstrapping Arch Linux.
 
-1. `clone https://github.com/r58Playz/terraos && mkdir -p terraos/build && cd terraos/build`
-2. Run `bash ../scripts/build_stage1.sh <defconfig>`
+1. `clone https://github.com/r58Playz/terraos && mkdir -p terraos/build && cd terraos/build{:sh}`
+2. Run `bash ../scripts/build_stage1.sh <defconfig>{:sh}`
    1. Use `terraos` as the defconfig if building for x86\_64 Chromebooks.
    2. Use `terraos_jacuzzi` as the defconfig if building for `jacuzzi` board Chromebooks. Support for `jacuzzi` board Chromebooks is experimental and may not work, however.
-3. Run `bash ../scripts/build_aur_packages.sh`
-4. Run `bash ../scripts/build_all.sh <shim.bin> <board_recovery.bin> <reven_recovery.bin>` replacing `<shim.bin>` with the path to a shim for your board, `<board_recovery.bin>` with the path to a recovery image for your board, and `<reven_recovery.bin>` with the path to a ChromeOS Flex recovery of the same version.
+3. Run `bash ../scripts/build_aur_packages.sh{:sh}`
+4. Run `bash ../scripts/build_all.sh <shim.bin> <board_recovery.bin> <reven_recovery.bin>{:sh}` replacing `<shim.bin>` with the path to a shim for your board, `<board_recovery.bin>` with the path to a recovery image for your board, and `<reven_recovery.bin>` with the path to a ChromeOS Flex recovery of the same version.
 
 This will place a built bootloader image, squashfs and tarballs of the arch rootfs, a bootloader image with the arch rootfs, a bootloader image with terraOS chromeOS, and a bootloader image with both the arch rootfs and terraOS chromeOS in the build directory.
 
@@ -34,10 +34,10 @@ The default arch rootfs user is `terraos` and its password is `terraos`.
 ## How do I install to internal storage?
 
 1. Boot into terraOS and copy over the image you used to flash your terraOS drive.
-2. Use GParted or `sudo fdisk -l` to find your internal storage. Replace `/dev/mmcblkX` in the rest of the steps with the internal storage device.
-3. Run `sudo dd if=<image> of=/dev/mmcblkX status=progress bs=16M oflag=direct` to write the image to the internal storage. Replace `<image>` with the path to the image you copied.
+2. Use GParted or `sudo fdisk -l{:sh}` to find your internal storage. Replace `/dev/mmcblkX` in the rest of the steps with the internal storage device.
+3. Run `sudo dd if=<image> of=/dev/mmcblkX status=progress bs=16M oflag=direct{:sh}` to write the image to the internal storage. Replace `<image>` with the path to the image you copied.
 
-Alternatively you can manually create a `chromeOS rootfs` type partition via `parted` or `fdisk`, format as ext4, and copy over the rootfs.
+Alternatively you can manually create a `chromeOS rootfs` type partition via `parted{:sh}` or `fdisk{:sh}`, format as ext4, and copy over the rootfs.
 
 ## FAQ
 

--- a/src/content/docs/kajigs/wallpaper.mdx
+++ b/src/content/docs/kajigs/wallpaper.mdx
@@ -17,10 +17,10 @@ Steps:
 5. right click desktop, click "Personalize" (or find "Personalize your device" in settings)
 6. go to "Wallpaper" → anything that's not "My Images" (for example: Cityscapes, Heritage, etc)
 7. click "Change Daily"
-8. it’ll throw an error but it changes the wallpaper anyway
+8. it'll throw an error but it changes the wallpaper anyway
 9. head back to the main Wallpaper menu again
 10. go to "My Images"
 11. select whatever image you want
-12. you’re done! have fun
+12. you're done! have fun
 
 You have to repeat steps 5-11 every time you restart

--- a/src/content/docs/proxies/rammerhead.mdx
+++ b/src/content/docs/proxies/rammerhead.mdx
@@ -2,15 +2,12 @@
 title: Rammerhead
 description: User friendly web proxy powered by testcafe-hammerhead.
 keywords: ["web proxy"]
+github: "https://github.com/binary-person/rammerhead"
+official-link: "https://demo-opensource.rammerhead.org"
+discord: "https://discord.gg/VNT4E7gN5Y"
 ---
 
 > Proxy based on testcafe-hammerhead (password is `sharkie4life`)
-
-[**GitHub**](https://github.com/binary-person/rammerhead)
-
-[**Demo link**](https://demo-opensource.rammerhead.org)
-
-[**Polished closed-source-for-now browser version**](https://browser.rammerhead.org)
 
 ## Contributions
 
@@ -36,7 +33,3 @@ node src/server.js
 ## Configuration
 
 Configure your settings in `src/config.js`. If you wish to consistently pull updates from this repo without the hassle of merging, create `config.js` in the root folder so they override the configs in `src/`.
-
-## Discord
-
-For any user-help non-issue related questions, especially pertaining to Rammerhead Browser, please ask them here: [Rammerhead Support Server](https://discord.gg/VNT4E7gN5Y).

--- a/src/content/docs/proxies/scramjet.mdx
+++ b/src/content/docs/proxies/scramjet.mdx
@@ -22,7 +22,7 @@ In the proxy community, you may see it abbreviated as "SJ".
 
 2. [Setup a transport on your site](../transports/using.mdx)
 
-3. Serve the Scramjet build under your specified route using the path `import { scramjetPath } from "@mercuryworkshop/scramjet"{:ts}`. We will use `/scram/` as a route for these examples.
+3. Serve the Scramjet build under your specified route using the path `import { scramjetPath } from "@mercuryworkshop/scramjet/path"{:ts}`. We will use `/scram/` as a route for these examples.
 
 4. Write a SW
 

--- a/src/content/docs/proxies/scramjet.mdx
+++ b/src/content/docs/proxies/scramjet.mdx
@@ -1,7 +1,104 @@
 ---
-title: Scramjet for Proxy Site Devs
-description: Scramjet is an experimental interception-based web proxy designed to evade internet censorship, bypass arbitrary web browser restrictions and innovate web proxy technologies. This project strives to maintain security, developer friendliness and performance unlike many other web proxies regardless of its open-source nature. 
+title: Scramjet
+description: An experimental interception-based web proxy designed to evade internet censorship, bypass arbitrary web browser restrictions and innovate web proxy technologies.
 keywords: ["web proxy", "sw proxy", "interception proxy"]
+github: "https://github.com/MercuryWorkshop/scramjet"
+official-link: "https://scramjet.mercurywork.shop"
 ---
 
-Scramjet is a modern interception proxy, which runs in the service worker, and has the highest levels of site support.
+<img width="200px" align="right" src="https://raw.githubusercontent.com/MercuryWorkshop/scramjet/refs/heads/main/assets/scramjet.png" alt="Official Scramjet Logo" height="250" />
+
+Scramjet is an interception-based web proxy designed to evade internet censorship, bypass arbitrary web browser restrictions and innovate web proxy technologies. It strives to maintain security, developer friendliness and performance unlike many other web proxies regardless of its open source nature.
+
+Scramjet is currently the flagship web proxy made by [Mercury Workshop](https://mercurywork.shop) and it is **highly recommended that you switch to it**. Don't worry, it is stable enough for most use cases to go into production!
+
+:::note
+In the proxy community, you may see it abbreviated as "SJ".
+:::
+
+# How to setup Scramjet on your proxy site
+
+1. Install the package: `pnpm install https://github.com/MercuryWorkshop/scramjet/releases/download/latest/mercuryworkshop-scramjet-1.0.2-dev.tgz{:sh}` (PNPM is recommended unless you use an alternative runtime like Bun)
+
+2. [Setup a transport on your site](../transports/using.mdx)
+
+3. Serve the Scramjet build under your specified route using the path `import { scramjetPath } from "@mercuryworkshop/scramjet"{:ts}`. We will use `/scram/` as a route for these examples.
+
+4. Write a SW
+
+`sw.js`:
+
+```js
+importScripts("/scram/scramjet.all.js");
+
+const { ScramjetServiceWorker } = $scramjetLoadWorker();
+const scramjet = new ScramjetServiceWorker();
+
+self.addEventListener("fetch", (event) => {
+	event.respondWith(async () => {
+    await scramjet.loadConfig();
+    if (scramjet.route(event)) {
+      return scramjet.fetch(event);
+    }
+
+    return fetch(event.request);
+  });
+});
+```
+
+5. Initialize `BareMux` and `ScramjetController`, and register your SW.
+
+Import the scripts in this order:
+
+1. BareMux
+2. BareMux Transport of your chioce
+3. Scramjet all bundle
+
+In your JS Script:
+
+```js
+const { ScramjetController } = $scramjetLoadController();
+
+const scramjet = new ScramjetController({
+  files: {
+	  wasm: "/scram/scramjet.wasm.wasm",
+	  all: "/scram/scramjet.all.js",
+	  sync: "/scram/scramjet.sync.js",
+  }
+});
+
+scramjet.init();
+
+navigator.serviceWorker.register("sw.js");
+
+// Init BareMux
+const connection = new BareMux.BareMuxConnection("/baremux/worker.js");
+// Set the transport yourself
+connection.setTransport(...);
+```
+
+## Learn from examples
+
+[Here is an example setup of Scramjet as a proxy site](https://github.com/MercuryWorkshop/Scramjet-App). If you get lost and need a reference along the way, you can fork it or take inspiration from it. It's essentially Ultraviolet-App, but with Scramjet as the SW proxy instead.
+
+## Upgrading to 1.0.2-dev+
+
+Now, Scramjet uses a new main bundle `scramjet.all.js`, which combines the former scripts.
+Replaces these bundles:
+
+```html
+<link rel="prefetch" href="/scram/scramjet.worker.js" />
+<link rel="prefetch" href="/scram/scramjet.shared.js" />
+...
+<script src="/scram/scramjet.controller.js"></script>
+```
+
+With:
+
+```html
+<script src="/scram/scramjet.all.js"></script>
+```
+
+## Upgrading from Ultraviolet
+
+Scramjet is easier to setup than UV. You may still use UV alongside Scramjet if you really find it necessary, however UV is unmaintained software and has far less site support than Scramjet.

--- a/src/content/docs/proxies/ultraviolet.mdx
+++ b/src/content/docs/proxies/ultraviolet.mdx
@@ -3,11 +3,16 @@ title: Ultraviolet
 description: A highly sophisticated proxy used for evading internet censorship or accessing websites in a controlled sandbox using the power of service-workers. Works by intercepting HTTP requests with a service worker script that follows the TompHTTP specifications.
 image: https://raw.githubusercontent.com/titaniumnetwork-dev/Ultraviolet-Static/main/public/uv.png
 keywords: ["web proxy", "sw proxy"]
+github: "https://github.com/titaniumnetwork-dev/Ultraviolet"
 ---
+
+:::note
+Ultraviolet is now unmaintained, and you are highly recommended to switch to [Scramjet](./scramjet.mdx)! We will not be providing further support for use of Ultraviolet.
+:::
 
 <img width="200px" align="right" src="https://raw.githubusercontent.com/titaniumnetwork-dev/Ultraviolet-Static/main/public/uv.png" height="250" />
 
-Ultraviolet is a highly advanced web proxy used for evading internet censorship or accessing websites in a controlled sandbox. It is designed with security and performance in mind. Ultraviolet intercepts HTTP requests with a service worker, using [libcurl.js](https://github.com/ading2210/libcurl.js) or [epoxy-tls](https://github.com/MercuryWorkshop/epoxy-tls) with [Wisp](https://github.com/MercuryWorkshop/wisp-protocol) and is a leader in innovative web proxy technologies.
+Ultraviolet is a web proxy used for evading internet censorship or accessing websites in a controlled sandbox. It is designed with security and performance in mind. Ultraviolet intercepts HTTP requests with a service worker, using a [BareMux transport](../transports/using.mdx).
 
 ## Features
 
@@ -18,20 +23,16 @@ Ultraviolet offers several features that set it apart from its predecessors, inc
 Some of the popular websites that Ultraviolet supports include:
 
 - [Google](https://google.com)
-- [Youtube](https://www.youtube.com)
-- [Spotify](https://spotify.com)
 - [Discord](https://discord.com)
 - [Reddit](https://reddit.com)
-- [GeForce NOW](https://play.geforcenow.com/)
-- [now.gg](https://now.gg)
 
 ## Used by
 
-- [Holy Unblocker](https://github.com/QuiteAFancyEmerald/Holy-Unblocker)
+- [Holy Unblocker](/services/holy-unblocker)
 - [Hypertabs](https://hypertabs.cc/)
-- [Terbium](https://github.com/TerbiumOS/webOS)
-- [Incognito](https://github.com/caracal-js/Incognito)
-- [Nebula](https://github.com/NebulaServices/Nebula)
+- [Terbium](/services/terbiumos)
+- [Incognito](/services/incognito)
+- [Nebula](/services/nebula)
 - [Noctura](https://github.com/NebulaServices/Noctura)
 - [Metallic](https://github.com/Metallic-Web/Metallic)
 
@@ -92,7 +93,7 @@ npm install @titaniumnetwork-dev/ultraviolet
 
 # 3.0.0
 
-- This version of Ultraviolet has support for using [bare-mux](https://github.com/MercuryWorkshop/bare-mux) transports, allowing for use for other implementations like [EpoxyTransport](https://github.com/MercuryWorkshop/EpoxyTransport), [CurlTransport](https://github.com/MercuryWorkshop/CurlTransport), and the existing implementation [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
+- This version of Ultraviolet has support for using [bare-mux](/transports/bare-mux) transports, allowing for use for other implementations like [EpoxyTransport](/transports/epoxy-transport), [CurlTransport](/transports/curl-transport), and the existing implementation [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
 
 # v2.0.0
 

--- a/src/content/docs/services/_category_.json
+++ b/src/content/docs/services/_category_.json
@@ -1,8 +1,8 @@
 {
-	"label": "Services",
-	"position": 2,
-	"link": {
-		"type": "generated-index",
-		"description": "Here is a quick overview if you wish to setup an open-source project from TitaniumNetwork on your own web server or just general SDK information in simple breakdowns."
-	}
+  "label": "Services",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Here is a quick overview if you wish to setup an open-source project from TitaniumNetwork on your own web server or just general SDK information in simple breakdowns."
+  }
 }

--- a/src/content/docs/services/anura.mdx
+++ b/src/content/docs/services/anura.mdx
@@ -2,6 +2,8 @@
 title: anuraOS
 description: A web "OS" and development environment with full linux emulation.
 keywords: ["webos", "proxy sites"]
+github: "https://github.com/MercuryWorkshop/anuraOS"
+official-link: "https://anura.pro"
 ---
 
 [![AnuraOS logo](https://raw.githubusercontent.com/MercuryWorkshop/anuraOS/main/assets/logo_dark.png)](https://github.com/MercuryWorkshop/anuraOS)
@@ -33,7 +35,7 @@ Anura will not build on Windows. Please use a Linux VM or WSL.
 
 ### Easy Install for GitHub Codespaces
 
-- Run `source codespace-basic-setup.sh`
+- Run `source codespace-basic-setup.sh{:sh}`
 
 :::note
 If you are not in a codespace skip to the regular installation steps.
@@ -57,7 +59,7 @@ This does NOT build RootFS.
 - An x86(-64) Linux PC (`make rootfs-alpine` build depends on x86 specific tools)
 
 :::note
-You will have to install the required Rust toolchains by running `rustup target add wasm32-unknown-unknown` and `rustup target add i686-unknown-linux-gnu` if you are planning to build v86 images.
+You will have to install the required Rust toolchains by running `rustup target add wasm32-unknown-unknown{:sh}` and `rustup target add i686-unknown-linux-gnu{:sh}` if you are planning to build v86 images.
 :::
 
 ### Building
@@ -68,7 +70,7 @@ make all
 ```
 
 :::tip
-You can use `make all -B` instead if you want to force a full build.
+You can use `make all -B{:sh}` instead if you want to force a full build.
 :::
 
 ### Building the Linux RootFS

--- a/src/content/docs/services/holy-unblocker.mdx
+++ b/src/content/docs/services/holy-unblocker.mdx
@@ -2,6 +2,8 @@
 title: Holy Unblocker LTS
 description: Holy Unblocker LTS is a web proxy service that helps you access websites that may be blocked by your network, government or policy all within your browser with no download or setup. It does this securely and with additional privacy features. Browse Tor/Onion sites in any browser, hide browsing activity and bypass filters. (Star if you fork it!)
 keywords: ["proxy sites"]
+github: "https://github.com/QuiteAFancyEmerald/Holy-Unblocker"
+official-link: "https://holyunblocker.org"
 ---
 
 <p align="center">
@@ -67,7 +69,7 @@ This website is hosted locally with Ultraviolet and Rammerhead built-in.
 - `terms.html`: Terms of Services, AUP and Privacy Policy page.
 - `gtools.html`: Games page, help from @BinBashBanana and @kinglalu.
 - `games5.html`: HTML5 game navigation page.
-- `emulators.html`: Emulator navigation page, using [webretro](https://github.com/BinBashBanana/webretro)
+- `emulators.html`: Emulator navigation page, using [webretro](/services/webretro)
 - `emulibrary.html`: Games page for emulated games (not included in public release)
 - `flash.html`: Games page for flash games, credits given to @BinBashBanana and Titanium Network for its assets.
 - `ultraviolet.html`: TODO
@@ -154,11 +156,11 @@ View the official website for more detail and credits.
 
 This project currently uses Ultraviolet, Wisp, Womginx, and Rammerhead, linked below.
 
-- [Ultraviolet](https://github.com/titaniumnetwork-dev/Ultraviolet)
+- [Ultraviolet](/proxies/ultraviolet)
 - [Womginx](https://github.com/binary-person/womginx)
-- [Rammerhead](https://github.com/binary-person/rammerhead)
-- [Wisp](https://github.com/MercuryWorkshop/wisp-server-node)
-- [Bare-Mux](https://github.com/MercuryWorkshop/bare-mux)
+- [Rammerhead](/proxies/rammerhead)
+- [Wisp](/technologies/wisp-server-node)
+- [Bare-Mux](/transports/bare-mux)
 - [Bare](https://github.com/tomphttp/bare-server-node)
 
 ### Other Dependencies:
@@ -166,7 +168,7 @@ This project currently uses Ultraviolet, Wisp, Womginx, and Rammerhead, linked b
 - [tsparticles](https://github.com/tsparticles/tsparticles)
 - [Helmet for Express](https://github.com/helmetjs/helmet)
 - [Modal](https://github.com/DerpmanDev/modal)
-- [webretro](https://github.com/BinBashBanana/webretro)
+- [webretro](/services/webretro)
 - [Ruffle](https://ruffle.rs/)
 - [AOS](https://github.com/michalsnik/aos)
 - [Nord Theme](https://github.com/nordtheme)

--- a/src/content/docs/services/incognito.mdx
+++ b/src/content/docs/services/incognito.mdx
@@ -2,6 +2,8 @@
 title: Incognito
 description: The official, up to date version of incognito.
 keywords: ["proxy sites"]
+github: "https://github.com/titaniumnetwork-dev/incognito"
+official-link: "https://incog.works"
 ---
 
 [![Incognito](https://socialify.git.ci/titaniumnetwork-dev/incognito/image?description=1\&font=Inter\&forks=1\&issues=1\&language=1\&name=1\&owner=1\&pattern=Circuit%20Board\&pulls=1\&stargazers=1\&theme=Dark)](https://github.com/titaniumnetwork-dev/incognito)
@@ -67,9 +69,9 @@ deno task start
 ```
 
 :::note
-You can run `deno task start:standalone` to use Hono over Fastify, recommended if you're using an external Wisp server like [Epoxy Server](https://github.com/mercuryworkshop/epoxy-tls)
+You can run `deno task start:standalone{:sh}` to use Hono over Fastify, recommended if you're using an external Wisp server like [Epoxy Server](/technologies/epoxy-server)
 
-You can run `deno task bstart` to build and start the server at the same time
+You can run `deno task bstart{:sh}` to build and start the server at the same time
 
 You can run `deno task bstart:standalone` to do the same as above but use the Hono server instead
 

--- a/src/content/docs/services/kazwire.mdx
+++ b/src/content/docs/services/kazwire.mdx
@@ -2,6 +2,9 @@
 title: Kazwire
 description: An unblocked games site that allows you to also browse the web freely!
 keywords: ["proxy sites", "emulator"]
+github: "https://github.com/whos-evan/kazwire"
+discord: "https://discord.gg/Ve7JBjpYJg"
+official-link: "https://kazwire.com"
 ---
 
 [![kazwire](https://socialify.git.ci/whos-evan/kazwire/image?description=1\&forks=1\&issues=1\&language=1\&logo=https%3A%2F%2Fkazwire.com%2Flogo.png\&name=1\&owner=1\&pattern=Solid\&pulls=1\&stargazers=1\&theme=Dark)](https://github.com/whos-evan/kazwire)
@@ -11,10 +14,6 @@ keywords: ["proxy sites", "emulator"]
 [![Repo Size](https://img.shields.io/github/repo-size/whos-evan/kazwire?style=for-the-badge)](https://github.com/whos-evan/kazwire)
 
 Kazwire allows you to play your favorite games whenever, wherever you need while also allowing you to browse the web freely and securely! If you like Kazwire please consider giving it a ⭐ on GitHub!
-
-## Support
-
-For support the fastest way to contact us is through Discord. Join our Discord server at [https://discord.gg/Ve7JBjpYJg](https://discord.gg/Ve7JBjpYJg).
 
 ## Installation
 

--- a/src/content/docs/services/nano.mdx
+++ b/src/content/docs/services/nano.mdx
@@ -2,6 +2,7 @@
 title: nano.
 description: A minimalist web proxy built to be simple yet powerful.
 keywords: ["proxy sites"]
+github: "https://github.com/titaniumnetwork-dev/nano"
 ---
 
 A minimalist web proxy built to be simple yet powerful.
@@ -25,19 +26,19 @@ pnpm install
 
 **Start**
 
-Run `pnpm start` to start the server. If no build folder is found, the app will build before starting.
+Run `pnpm start{:sh}` to start the server. If no build folder is found, the app will build before starting.
 
 **Build**
 
-Run `pnpm run build` to build the app for production into the `dist` folder.
+Run `pnpm run build{:sh}` to build the app for production into the `dist` folder.
 
 **Build Static**
 
-Run `pnpm run build-static` to build the app for production into the `dist` folder. This is for static hosting on GitHub Pages etc. Make sure to change the Wisp server in `/index.html` to an external one.
+Run `pnpm run build-static{:sh}` to build the app for production into the `dist` folder. This is for static hosting on GitHub Pages etc. Make sure to change the Wisp server in `/index.html` to an external one.
 
 **Development**
 
-Run `pnpm run dev` to run the app in development mode.
+Run `pnpm run dev{:sh}` to run the app in development mode.
 
 ## Developers
 

--- a/src/content/docs/services/nebula.mdx
+++ b/src/content/docs/services/nebula.mdx
@@ -2,6 +2,8 @@
 title: Nebula
 description: A stunning and sleek web proxy with support for hundreds of popular sites.
 keywords: ["proxy sites"]
+github: "https://github.com/NebulaServices/Nebula"
+official-link: "https://nebulaproxy.io"
 ---
 
 [![repo](https://socialify.git.ci/nebulaservices/nebula/image?description=1\&font=Inter\&forks=1\&issues=1\&language=1\&name=1\&owner=1\&pattern=Circuit%20Board\&pulls=1\&stargazers=1\&theme=Dark)](https://github.com/nebulaservices/nebula)
@@ -33,8 +35,8 @@ This will **NOT** work on Render
 ## Features
 
 - Multiple Proxy "Backends":
-  - [Ultraviolet](https://github.com/titaniumnetwork-dev/ultraviolet)
-  - [Rammerhead](https://github.com/binary-person/rammerhead)
+  - [Ultraviolet](/proxies/ultraviolet)
+  - [Rammerhead](/proxies/rammerhead)
 
 ---
 
@@ -49,9 +51,9 @@ This will **NOT** work on Render
 
 - [Astro](https://astro.build)
 - [Fastify](https://fastify.dev)
-- [Ultraviolet](https://github.com/titaniumnetwork-dev/ultraviolet)
-- [Rammerhead](https://github.com/binary-person/rammerhead)
-- [Epoxy](https://github.com/mercuryworkshop/epoxy-tls)
+- [Ultraviolet](/proxies/ultraviolet)
+- [Rammerhead](/proxies/rammerhead)
+- [Epoxy](/technologies/epoxy-server)
 - [Libcurl.js](https://github.com/ading2210/libcurl.js)
 - HTML, CSS, and JavaScript (DUH)
 
@@ -94,7 +96,7 @@ This will **NOT** work on Render
 ```
 
 :::note
-You can add a custom font as well! To do so, add this to your `:root`
+You can add a custom font as well! To do so, add this to your `:root{:css}`
 
 ```css
 --font-family: /* Font family name */;
@@ -130,7 +132,7 @@ A good example of using a custom font is the built-in `retro` theme [here](./dat
 
 ##### Serviceworker plugin:
 
-- These plugins are handled by Workerware see [here](https://github.com/mercuryworkshop/workerware) for docs.
+- These plugins are handled by Workerware see [here](/technologies/workerware) for docs.
 
 1. Create an index.js (or other file name) file:
 
@@ -146,7 +148,7 @@ touch index.js
        return {
            function: `console.log('Example code.')`,
            name: 'com.example', // Technically, it could be named anything. It is recommended to use the same name for everything (name when submitting and this)        
-           events: ['fetch'] // See: https://github.com/mercuryworkshop/workerware for the event types you can use. (Also typed if you are using typescript)
+           events: ['fetch'] // See: /technologies/workerware for the event types you can use. (Also typed if you are using typescript)
        }
    }
 
@@ -164,7 +166,7 @@ touch index.js
        return {
            function: example, //Do not call the function, only assign the reference to the function.
            name: 'com.example', // Technicall could be name anything. Recommended to use the same name for everything (name when submitting and this)
-           event: ['fetch'] // Se https://github.com/mercuryworkshop/workerware for the event types you can use. (Also typed if using typescript)
+           event: ['fetch'] // See /technologies/workerware for the event types you can use. (Also typed if using typescript)
        }
    }
 
@@ -175,7 +177,7 @@ touch index.js
 :::caution
 The only *allowed* way to pass code to the `function` param is either a string or an arrow function. Named functions ***WILL NOT WORK***.
 
-Example of a named function: `function example() {/* Some form of code */}`.
+Example of a named function: `function example() {/* Some form of code */}{:js}`.
 
 If a named function is used where it shouldn't be, your plugin will not be approved, nor will it work properly.
 :::
@@ -259,7 +261,7 @@ npm start
 ```
 
 :::note
-You can run `npm run bstart` to build and start together
+You can run `npm run bstart{:sh}` to build and start together
 :::
 
 ### Docker

--- a/src/content/docs/services/radon-games.mdx
+++ b/src/content/docs/services/radon-games.mdx
@@ -2,6 +2,8 @@
 title: Radon Games
 description: An open-source unblocked games website built with simplicity in mind.
 keywords: ["proxy sites", "emulator"]
+github: "https://github.com/Radon-Games/Radon-Games"
+official-link: "https://radon.games"
 ---
 
 <p align="center">
@@ -85,4 +87,4 @@ In order to add games to Radon, you will first need to download the game files u
 - [solid-slider](https://www.npmjs.com/package/solid-slider)
 - [fuzzysort](https://www.npmjs.com/package/fuzzysort)
 - [vanilla-tilt](https://www.npmjs.com/package/vanilla-tilt)
-- [Ultraviolet](https://github.com/titaniumnetwork-dev/Ultraviolet) (proxy)
+- [Ultraviolet](../proxies/ultraviolet.mdx) (proxy)

--- a/src/content/docs/services/terbiumos.mdx
+++ b/src/content/docs/services/terbiumos.mdx
@@ -2,6 +2,9 @@
 title: TerbiumOS
 description: The next generation of Terbium WebOS, built to last!
 keywords: ["webos", "proxy sites"]
+github: "https://github.com/TerbiumOS/web-v2"
+discord: "https://discord.gg/WC7n6PskAK"
+official-link: "https://terbiumon.top/"
 ---
 
 <center>
@@ -16,7 +19,7 @@ keywords: ["webos", "proxy sites"]
 - [TailwindCSS](https://tailwindcss.com)
 - [FilerJS](https://github.com/filerjs/filer)
 - [Fflate](https://github.com/101arrowz/fflate/)
-- [BareMux](https://github.com/mercuryworkshop/bare-mux)
+- [BareMux](/transports/bare-mux)
 
 ## <span style="color: #32ae62;">Features</span>
 
@@ -33,7 +36,7 @@ keywords: ["webos", "proxy sites"]
 
 > <span style="font-family: url('https://fonts.googleapis.com/css2?family=Roboto&display=swap'); color: #ffd900;">⚠</span> <span style="color: #ffd900;">NOTE:</span> Terbium **WILL NOT** build on versions of Node older than version 20.
 
-To get started it's pretty easy you need either npm or pnpm which can be installed by running: `npm i -g pnpm` and then just need to run the following command
+To get started it's pretty easy you need either npm or pnpm which can be installed by running: `npm i -g pnpm{:sh}` and then just need to run the following command
 
 ```bash
 pnpm i && pnpm start # Replace pnpm with npm if your not going to use pnpm
@@ -41,7 +44,7 @@ pnpm i && pnpm start # Replace pnpm with npm if your not going to use pnpm
 
 and visit [http://localhost:3000](http://localhost:3000) you should be good to go!
 
-If you are developing/modifying Terbium you can just run `pnpm run dev`, **DO NOT** use the development server for production use instead just run `pnpm start`. For any further backend configuration visit the `.env` file to configure the backend a bit.
+If you are developing/modifying Terbium you can just run `pnpm run dev{:sh}`, **DO NOT** use the development server for production use instead just run `pnpm start{:sh}`. For any further backend configuration visit the `.env` file to configure the backend a bit.
 
 > <span style="font-family: none; color: #ffd900;">⚠</span> <span style="color: #ffd900;">Warning</span><br />
 > If you are going to static host Terbium you will need to change the wisp server and you would need to follow those steps. Refer to this [document](https://github.com/TerbiumOS/web-v2/tree/main/docs/static-hosting.md) for more information

--- a/src/content/docs/services/webretro.mdx
+++ b/src/content/docs/services/webretro.mdx
@@ -2,13 +2,12 @@
 title: webretro
 description: RetroArch in your browser.
 keywords: ["emulator"]
+github: "https://github.com/BinBashBanana/webretro"
+official-link: "https://binbashbanana.github.io/webretro"
 ---
 
-[RetroArch](https://github.com/libretro) ported to WebAssembly with [emscripten](https://emscripten.org/)!
+[RetroArch](https://github.com/libretro) ported to WebAssembly with [emscripten](https://emscripten.org)!
 
-[**Official Instance**](https://binbashbanana.github.io/webretro/)
-
-[**GitHub**](https://github.com/BinBashBanana/webretro)
 
 ### Latest version: v6.5
 
@@ -92,7 +91,7 @@ Example OK query uris:
 
 You can easily embed webretro on your site by using the api provided in `embed/embed.js`. You can see an example of it [here](https://binbashbanana.github.io/webretro/embed/embed-example.html).
 
-How to use: `webretroEmbed(domNodeToAppendTo, webretroPath, queries)` (returns the new iframe node that it creates)
+How to use: `webretroEmbed(domNodeToAppendTo, webretroPath, queries){:js}` (returns the new iframe node that it creates)
 
 - `domNodeToAppendTo` - the element that you want webretro to load into.
 - `webretroPath` - the path to the index of the webretro instance.

--- a/src/content/docs/technologies/epoxy-server.mdx
+++ b/src/content/docs/technologies/epoxy-server.mdx
@@ -2,6 +2,7 @@
 title: Epoxy Server
 description: An encrypted proxy for browser javascript.
 keywords: ["transport"]
+github: "https://github.com/MercuryWorkshop/epoxy-tls"
 ---
 
 Performant server implementation of the [Wisp](/wisp) protocol in Rust, made for epoxy.

--- a/src/content/docs/technologies/masqr.mdx
+++ b/src/content/docs/technologies/masqr.mdx
@@ -2,6 +2,7 @@
 title: Masqr
 description: Masqr is an "anti link leaking" authentication system that allows you to use a domain on specific devices to prevent web filters from detecting a web service.  The project also is a go-to method for site cloaking with other web sources protecting the main domain.
 keywords: ["filtering protection"]
+github: "https://github.com/titaniumnetwork-dev/MasqrProject"
 ---
 
 ## What is MASQR?

--- a/src/content/docs/technologies/serverguard.mdx
+++ b/src/content/docs/technologies/serverguard.mdx
@@ -2,6 +2,7 @@
 title: Serverguard
 description: TN's Double Counter alternative; known locally as ProxyGuard or Cybermonay.
 keywords: ["discord bot"]
+github: "https://github.com/titaniumnetwork-dev/serverguard"
 ---
 
 An open source alternative to Double Counter. Known within the Titanium Network community as "Cybermonay" or "Proxyguard". Created in response to mistrust of DC's development team as well as a desire to put control of network data back in the hands of our users.

--- a/src/content/docs/technologies/whisper.mdx
+++ b/src/content/docs/technologies/whisper.mdx
@@ -2,6 +2,7 @@
 title: Whisper
 description: Wisp protocol client that exposes the Wisp connection over a TUN device.
 keywords: ["transport", "vpn"]
+github: "https://github.com/MercuryWorkshop/whisper"
 ---
 
 Wisp protocol client that exposes the Wisp connection over a TUN device.

--- a/src/content/docs/technologies/wisp-server-node.mdx
+++ b/src/content/docs/technologies/wisp-server-node.mdx
@@ -1,7 +1,8 @@
 ---
-title: Wisp Server Node
-description: A wisp server implementation, written in NodeJS.
+title: Node Wisp Server
+description: A Wisp server implementation, written in NodeJS.
 keywords: ["transport"]
+github: "https://github.com/MercuryWorkshop/wisp-server-node"
 ---
 
 A [wisp protocol](/wisp) server implementation, written in NodeJS.
@@ -34,7 +35,7 @@ wisp-server-node doesn't need to handle regular requests, just upgrade events.
 
 ### Is it fast? 🚀
 
-It's good enough for testing, it's easy to integrate into your existing app, and maybe it's good enough for light production usage, but chances are if you're at the scale where you're running a reverse proxy, you should use [epoxy-server](https://github.com/MercuryWorkshop/epoxy-tls) which will deliver better performance at a lower memory footprint
+It's good enough for testing, it's easy to integrate into your existing app, and maybe it's good enough for light production usage, but chances are if you're at the scale where you're running a reverse proxy, you should use [epoxy-server](/technologies/epoxy-server) which will deliver better performance at a lower memory footprint
 
 ### Is it API stable? 🐎
 

--- a/src/content/docs/technologies/wisp-server-python.mdx
+++ b/src/content/docs/technologies/wisp-server-python.mdx
@@ -1,0 +1,69 @@
+---
+title: Python Wisp Server
+description: an implementation of a Wisp server, written in Python. It follows the Wisp v1 spec completely, including support for UDP connections.
+keywords: ["transport"]
+github: "https://github.com/MercuryWorkshop/wisp-server-python"
+---
+
+This is an implementation of a [Wisp](https://github.com/MercuryWorkshop/wisp-protocol) server, written in Python. It follows the Wisp v1 spec completely, including support for UDP connections.
+
+# Installation:
+
+## Install From Source:
+
+Clone [the repository](https://github.com/MercuryWorkshop/wisp-server-python) and cd into it, then run the following commands:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -e .
+```
+
+### Install From PyPI:
+
+Run the following command to install this program:
+
+```sh
+pip3 install wisp-python
+```
+
+# Running the Server:
+
+For the best performance use [CPython](https://github.com/python/cpython) 3.11 or newer. [PyPy](https://github.com/pypy/pypy) is not recommended as it is a lot slower than CPython here.
+
+To start the server, run `python3 -m wisp.server{:sh}`. The program accepts the following arguments:
+
+```
+usage: wisp-server-python [-h] [--host HOST] [--port PORT] [--static STATIC] [--limits] [--bandwidth BANDWIDTH] [--connections CONNECTIONS] [--window WINDOW] [--allow-loopback] [--allow-private] [--log-level LOG_LEVEL]
+                          [--threads THREADS] [--proxy PROXY] [--block-udp] [--block-tcp]
+
+A Wisp server implementation, written in Python (v0.8.1)
+
+options:
+  -h, --help            show this help message and exit
+  --host HOST           The hostname the server will listen on.
+  --port PORT           The TCP port the server will listen on.
+  --static STATIC       Where static files are served from.
+  --limits              Enable rate limits.
+  --bandwidth BANDWIDTH
+                        Bandwidth limit per IP, in kilobytes per second.
+  --connections CONNECTIONS
+                        New connections limit per IP.
+  --window WINDOW       Fixed window length for rate limits, in seconds.
+  --allow-loopback      Allow connections to loopback IP addresses.
+  --allow-private       Allow connections to private IP addresses.
+  --log-level LOG_LEVEL
+                        The log level (either debug, info, warning, error, or critical).
+  --threads THREADS     The number of threads to run the server on. By default it uses all CPU cores. (Linux only)
+  --proxy PROXY         The url of the socks5h, socks5, sock4a, socks4 or http proxy to use.
+  --block-udp           Block UDP streams.
+  --block-tcp           Block TCP streams.
+```
+
+# Roadmap:
+
+- ~~Rate limits~~
+- JSON based config files
+- ~~UDP support~~
+- ~~Ability to block local addresses~~
+- Wisp v2 support

--- a/src/content/docs/technologies/wispmark.mdx
+++ b/src/content/docs/technologies/wispmark.mdx
@@ -2,6 +2,7 @@
 title: WispMark
 description: A benchmarking tool for Wisp protocol implementations.
 keywords: ["transport", "benchmarking"]
+github: "https://github.com/MercuryWorkshop/wispmark"
 ---
 
 WispMark is a benchmarking tool for [Wisp](/wisp) protocol implementations.
@@ -29,10 +30,10 @@ This program pairs each Wisp server with each Wisp client, with a TCP echo serve
 
 Server:
 
-- [wisp-server-node](https://github.com/MercuryWorkshop/wisp-server-node)
+- [wisp-server-node](/technologies/wisp-server-node)
 - [wisp-js](https://github.com/MercuryWorkshop/wisp-client-js/blob/rewrite)
-- [wisp-server-python](https://github.com/MercuryWorkshop/wisp-server-python)
-- [epoxy-server](https://github.com/MercuryWorkshop/epoxy-tls/tree/multiplexed/server)
+- [wisp-server-python](/technologies/wisp-server-python)
+- [epoxy-server](/technologies/epoxy-server)
 - [WispServerCpp](https://github.com/FoxMoss/WispServerCpp)
 
 Client:

--- a/src/content/docs/technologies/workerware.mdx
+++ b/src/content/docs/technologies/workerware.mdx
@@ -2,6 +2,7 @@
 title: Workerware
 description: A simple express-style middleware layer for service workers.
 keywords: ["sw proxy", "middleware"]
+github: "https://github.com/MercuryWorkshop/workerware"
 ---
 
 A simple express-style middleware layer for service workers.

--- a/src/content/docs/transports/bare-mux.mdx
+++ b/src/content/docs/transports/bare-mux.mdx
@@ -2,9 +2,10 @@
 title: bare-mux
 description: A system for managing http transports in a project such as Ultraviolet.
 keywords: ["sw proxy", "transport", "bare mux"]
+github: "https://github.com/MercuryWorkshop/bare-mux"
 ---
 
-Bare-mux is a system for managing HTTP transports in projects like [Ultraviolet](https://github.com/Titaniumnetwork-dev/Ultraviolet) or [Scramjet](https://github.com/MercuryWorkshop/Scramjet).
+Bare-mux is a system for managing HTTP transports in projects like [Ultraviolet](/proxies/ultraviolet) or [Scramjet](/proxies/scramjet).
 It is responsible for whether libcurl, Epoxy, Bare as module v3, or any other transport is used in those projects.
 
 Written to make the job of creating new standards for transporting http data seamless.
@@ -60,7 +61,7 @@ npm install @mercuryworkshop/bare-mux@1
 
 ## Usage
 
-Examples of transports include [EpoxyTransport](https://github.com/MercuryWorkshop/EpoxyTransport), [CurlTransport](https://github.com/MercuryWorkshop/CurlTransport), and [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
+Examples of transports include [EpoxyTransport](/transports/epoxy-transport), [CurlTransport](/transports/curl-transport), and [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
 
 Here is an example of using bare-mux:
 

--- a/src/content/docs/transports/curl-transport.mdx
+++ b/src/content/docs/transports/curl-transport.mdx
@@ -2,6 +2,7 @@
 title: CurlTransport
 description: A bare transport that implements end-to-end encryption with libcurl.js and wisp.
 keywords: ["sw proxy", "transport", "bare mux"]
+github: "https://github.com/MercuryWorkshop/CurlTransport"
 ---
 
 A bare-module for implementing end-to-end encryption with libcurl.js

--- a/src/content/docs/transports/epoxy-transport.mdx
+++ b/src/content/docs/transports/epoxy-transport.mdx
@@ -2,9 +2,10 @@
 title: EpoxyTransport
 description: A bare transport that implements end-to-end encryption with epoxy-tls and wisp.
 keywords: ["sw proxy", "transport"]
+github: "https://github.com/MercuryWorkshop/EpoxyTransport"
 ---
 
-EpoxyTransport is a transport for bare-mux which allows you to use [epoxy-tls](https://github.com/MercuryWorkshop/epoxy-tls) in your bare client.
+EpoxyTransport is a transport for bare-mux which allows you to use [epoxy-tls](/technologies/epoxy-server) in your bare client.
 
 Usage of this transport is as simple as setting the transport and providing a wisp server. An example is shown below where you get connected to the public testing wisp server.
 

--- a/src/content/docs/transports/using.mdx
+++ b/src/content/docs/transports/using.mdx
@@ -6,11 +6,11 @@ keywords: ["transport"]
 
 ## Picking a transport
 
-Some examples of transports are [EpoxyTransport](https://github.com/MercuryWorkshop/EpoxyTransport), [CurlTransport](https://github.com/MercuryWorkshop/CurlTransport), and [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
+Some examples of transports are [EpoxyTransport](/transports/epoxy-transport), [CurlTransport](/transports/curl-transport), and [Bare-Client](https://github.com/MercuryWorkshop/Bare-as-module3).
 
 ### Hosting files
 
-Your files should be statically available from your web server. For this example [EpoxyTransport](https://github.com/MercuryWorkshop/EpoxyTransport) will be hosted at `/epoxy/` and [bare-mux](https://github.com/MercuryWorkshop/bare-mux) will be hosted at `/baremux/`
+Your files should be statically available from your web server. For this example [EpoxyTransport](/transports/epoxy-transport) will be hosted at `/epoxy/` and [bare-mux](/transports/bare-mux) will be hosted at `/baremux/`
 
 When using express, all transports and bare-mux provide a path that can be imported into your backend that hosts the static files. An example is shown below.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-	"extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "exclude": ["dist", "node_modules", ".astro"]
 }


### PR DESCRIPTION
- Document Scramjet and wisp-server-python
- Officially deprecate UV and recommend Scramjet as the flagship web proxy
- Resolve relative MD links and prefer them over external GitHub Repo links for projects we have already documented locally
- Add new frontmatter fields, which create respective buttons for better referencing to external sources for the projects documented
- Colorize inline codeblocks
- Switch the default codeblock theme to be tokyo-night