### PR TITLE
kajigs revamp

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection, z, getCollection } from "astro:content";
 import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
@@ -8,7 +8,19 @@ export const collections = {
         github: z.string().optional(),
         discord: z.string().optional(),
         "official-link": z.string().optional(),
+        kernver: z.number().optional(),
       }),
     }),
   }),
 };
+
+export async function getkajigs() {
+  const kajigs = ( await getCollection("docs")).filter((doc) => doc.id.startsWith("kajigs/") && doc.id !== "kajigs" && doc.data.kernver !== undefined );
+  const kernver: Record<number, { title: string; slug: string }[]> = {};
+  for (const doc of kajigs) {
+    const key = doc.data.kernver!;
+    if (!kernver[key]) kernver[key] = [];
+    kernver[key].push({ title: doc.data.title, slug: `/${doc.slug}` });
+  }
+  return kernver;
+}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard title="Guides" href="/guides/" />
 
-  <LinkCard title="Kajigs" href="/kajigs/caub/" />
+  <LinkCard title="Kajigs" href="/kajigs/" />
 
   <LinkCard title="Proxies" href="/proxies/ultraviolet/" />
 

--- a/src/content/docs/kajigs/caub.mdx
+++ b/src/content/docs/kajigs/caub.mdx
@@ -2,6 +2,7 @@
 title: Caub (<v128)
 description: Documentation for Caub.
 keywords: ["chromeos exploits", "dns"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/caubdns-proxy-editor.mdx
+++ b/src/content/docs/kajigs/caubdns-proxy-editor.mdx
@@ -2,6 +2,7 @@
 title: CaubDNS Proxy Editor (>v128)
 description: Documentation for CaubDNS Proxy Editor.
 keywords: ["chromeos exploits", "dns"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/caudns.mdx
+++ b/src/content/docs/kajigs/caudns.mdx
@@ -2,6 +2,7 @@
 title: CauDNS (<v128)
 description: Documentation for CauDNS.
 keywords: ["chromeos exploits", "dns"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/connection-on-whitelisted-wifi.mdx
+++ b/src/content/docs/kajigs/connection-on-whitelisted-wifi.mdx
@@ -2,6 +2,7 @@
 title: Connect to non-whitelisted Wi-Fi Networks (v124-v131)
 description: Documentation for connecting to non-whitelisted Wi-Fi Networks.
 keywords: ["chromeos exploits", "wifi"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/dump-kiosk.mdx
+++ b/src/content/docs/kajigs/dump-kiosk.mdx
@@ -2,6 +2,7 @@
 title: Dump ChromeOS Kiosk Apps as Chrome Apps
 description: Documentation for Dump ChromeOS Kiosk Apps as Chrome Apps.
 keywords: ["chromeos exploits"]
+kernver: 0
 ---
 
 :::note

--- a/src/content/docs/kajigs/incognito.mdx
+++ b/src/content/docs/kajigs/incognito.mdx
@@ -2,6 +2,7 @@
 title: Incognito (v123-127)
 description: Documentation for Incognito.
 keywords: ["chromeos exploits"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/index.mdx
+++ b/src/content/docs/kajigs/index.mdx
@@ -1,0 +1,52 @@
+---
+title: Kajigs
+description: Information about Kajigs and their role in Titanium Network.
+sidebar:
+  order: 1
+kernvers:
+    0: All
+    1: <v112
+    2: v112-v119
+    3: v120-v123
+    4: v124-v132
+    5: v132-v137
+    6: v138+
+---
+
+## What is a kajig?
+Kajigs are exploits/tools, typically made for use on managed devices.
+
+#### Where can I find them?
+Kajigs can be found in [Titanium Network's Discord server](https://discord.gg/unblock) after verifying. Kajigs are located in the `kajig-the-things` category. This category has several kajig-related channels listed below.
+  1. `#kajigs-info`: Has information about the various tags/categories that kajigs have
+  2. `#kajigs-helpdesk`: A threads channel for recieving help from TN's Librarians.
+  3. `#kajigs`: The main kajigs threads channel, for things such as Chromebooks, iOS devices, and Windows devices.
+  4. `#webview-kajigs`: Threads channel exclusively for exploits allowing limited, but unblocked browsers
+  5. `#read-only-kajigs`: Threads channel containing exploits that are locked. Not much in here, aside from [Galapagos](/kajigs/galapagos)
+  4. `#kajigs-discussion`: Talk about kajigs in general, if you use it for help you probably won't get an answer. (See: `#kajigs-helpdesk`)
+
+#### Who makes kajigs?
+Kajigs can be posted by anyone with the `Programmer` or `samyk` roles in the Discord server. Webview Kajigs can be posted by anyone.
+
+### What kajigs can I use?
+
+import { getkajigs } from '../../config.ts';
+export const kernver = await getkajigs()
+
+Most kajigs can be used in all previous Kernvers. 
+
+For example, Rigtools can be used on any Kernver that can be used below 128, which would be Kernvers 1, 2, 3, and 4.
+
+| Kernver | ChromeOS Versions | Kajigs |
+| ------- | ----------------- | ------ |
+| Any     | {frontmatter.kernvers[0]} | {kernver[0]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 1       | {frontmatter.kernvers[1]} | {kernver[1]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 2       | {frontmatter.kernvers[2]} | {kernver[2]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 3       | {frontmatter.kernvers[3]} | {kernver[3]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 4       | {frontmatter.kernvers[4]} | {kernver[4]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 5       | {frontmatter.kernvers[5]} | {kernver[5]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+| 6       | {frontmatter.kernvers[6]} | {kernver[6]?.map(k => <a href={k.slug}>{k.title}</a>).reduce((a, b) => [a, ", ", b])} |
+
+:::note
+    If you are on Kernver 1, you can recover to any version. However, if a kajig is listed as Kernver 1, it can only be done below v112.
+:::

--- a/src/content/docs/kajigs/kajigs.mdx
+++ b/src/content/docs/kajigs/kajigs.mdx
@@ -1,5 +1,0 @@
----
-title: Guides
-description: Documentation for Guides.
-keywords: ["chromeos exploits"]
----

--- a/src/content/docs/kajigs/ltmeat.mdx
+++ b/src/content/docs/kajigs/ltmeat.mdx
@@ -2,6 +2,7 @@
 title: LTMEAT (<v114)
 description: Documentation for LTMEAT Exploit.
 keywords: ["chromeos exploits"]
+kernver: 2
 ---
 
 :::note

--- a/src/content/docs/kajigs/omada-dns.mdx
+++ b/src/content/docs/kajigs/omada-dns.mdx
@@ -2,6 +2,7 @@
 title: Omada DNS
 description: Documentation for Omada DNS.
 keywords: ["chromeos exploits", "dns"]
+kernver: 0
 ---
 
 [Omada](https://omada.cafe) is a community and small group of people working on hosting free and open source services on the basis of freedom, privacy and decentralization.

--- a/src/content/docs/kajigs/protonvpn.mdx
+++ b/src/content/docs/kajigs/protonvpn.mdx
@@ -2,6 +2,7 @@
 title: Proton VPN on ChromeOS (<v129)
 description: Documentation for Proton VPN.
 keywords: ["chromeos exploits", "vpn"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/rigtools.mdx
+++ b/src/content/docs/kajigs/rigtools.mdx
@@ -1,7 +1,8 @@
 ---
-title: Rigtools (<v124)
+title: Rigtools (<v128)
 description: Documentation for a Developer Tools Exploit.
 keywords: ["chromeos exploits"]
+kernver: 4
 ---
 
 :::note

--- a/src/content/docs/kajigs/rootless-unenrollment.mdx
+++ b/src/content/docs/kajigs/rootless-unenrollment.mdx
@@ -2,6 +2,7 @@
 title: Rootless Unenrollment (≤v101)
 description: Documentation for Rootless Unenrollment.
 keywords: ["chromeos exploits"]
+kernver: 1
 ---
 
 :::note

--- a/src/content/docs/kajigs/shimboot.mdx
+++ b/src/content/docs/kajigs/shimboot.mdx
@@ -2,6 +2,7 @@
 title: Shimboot
 description: Boot a desktop Linux distribution from a Chrome OS RMA shim.
 keywords: ["chromeos exploits"]
+kernver: 0
 ---
 
 :::note

--- a/src/content/docs/kajigs/terra.mdx
+++ b/src/content/docs/kajigs/terra.mdx
@@ -2,6 +2,7 @@
 title: terraOS
 description: Documentation for terraOS.
 keywords: ["chromeos exploits"]
+kernver: 0
 ---
 
 Boot Linux-based operating systems from a RMA shim.

--- a/src/content/docs/kajigs/vmc.mdx
+++ b/src/content/docs/kajigs/vmc.mdx
@@ -2,6 +2,7 @@
 title: Crosh+VMC (<v124)
 description: Documentation for Crosh+VMC.
 keywords: ["chromeos exploits"]
+kernver: 3
 ---
 
 :::note

--- a/src/content/docs/kajigs/wallpaper.mdx
+++ b/src/content/docs/kajigs/wallpaper.mdx
@@ -2,6 +2,7 @@
 title: Forcibly Change Wallpaper (v99-v104)
 description: Documentation for Forcibly Change Wallpaper.
 keywords: ["chromeos exploits"]
+kernver: 1
 ---
 
 :::note


### PR DESCRIPTION
add dynamic table to /kajigs/(index.mdx) that reads kernver: * from the frontmatter in kajigs and formats properly.

also adds explanation of kajigs and their role in TN
<img width="495" height="552" alt="table" src="https://github.com/user-attachments/assets/600acd19-1024-4511-9c6c-6fa072db70de" />
