### PR TITLE
Fix typo in UFW firewall rules

### DIFF
--- a/src/content/docs/guides/vpn-setup.mdx
+++ b/src/content/docs/guides/vpn-setup.mdx
@@ -81,7 +81,7 @@ Run these four commands:
 ```sh
 sudo ufw allow OpenSSH
 sudo ufw allow 500,4500/udp
-sudo ufw allow 5
+sudo ufw allow 53
 sudo ufw enable
 ```
 


### PR DESCRIPTION
Replace 'allow 5' with 'allow 53' in UFW rules for VPN setup.